### PR TITLE
Fix timestamps option for dumper applications and add dumper application for simulation

### DIFF
--- a/scripts/walking-dumper-sim-min.xml
+++ b/scripts/walking-dumper-sim-min.xml
@@ -1,0 +1,123 @@
+<!-- Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia (IIT) -->
+<!-- All Rights Reserved. -->
+
+<application>
+    
+    <name>Walking data dumper module</name>
+    <description>collects data from the sensor suite for offline processing</description>
+    <authors>
+        <author email="prashanth.ramadoss@iit.it">Prashanth Ramadoss</author>
+        <author email="silvio.traversaro@iit.it">Silvio Traversaro</author>
+    </authors>
+
+    <dependencies>                         
+        <!-- BASE IMU -->
+        <port>/icubSim/xsens_inertial</port>
+        
+        <!-- CONTACT WRENCHES -->
+        <port>/wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o</port>
+        <port>/wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o</port>
+        
+        <!-- JOINT STATES -->
+        <port>/icubSim/all_joints/state:o</port>
+        
+        <!-- Link states  -->        
+        <port>/icubSim/floating_base/state:o</port>
+        <port>/icubSim/l_foot/state:o</port>
+        <port>/icubSim/r_foot/state:o</port>
+    </dependencies>
+    
+    
+    <!-- Link states  -->   
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/floating_base/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-floating_base-state:o</tag>
+    </module>
+    <connection>
+        <from>/icubSim/floating_base/state:o</from>
+        <to>/dumper/icubSim/floating_base/state:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/l_foot/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-l_foot-state:o</tag>
+    </module>
+    <connection>
+        <from>/icubSim/l_foot/state:o</from>
+        <to>/dumper/icubSim/l_foot/state:o</to>
+        <protocol>udp</protocol>        
+    </connection> 
+    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/r_foot/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-r_foot-state:o</tag>
+    </module>
+    <connection>
+        <from>/icubSim/r_foot/state:o</from>
+        <to>/dumper/icubSim/r_foot/state:o</to>
+        <protocol>udp</protocol>        
+    </connection>  
+     
+    
+           
+    <!-- BASE IMU -->    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/waist/inertial --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-waist-inertial</tag>
+    </module>    
+    <connection>
+        <from>/icubSim/xsens_inertial</from>
+        <to>/dumper/icubSim/waist/inertial</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+    <!-- CONTACT WRENCHES -->
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/left_foot/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-left_foot-cartesianEndEffectorWrench:o</tag>
+    </module>    
+    <connection>
+        <from>/wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o</from>
+        <to>/dumper/icubSim/left_foot/cartesianEndEffectorWrench:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/right_foot/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-right_foot-cartesianEndEffectorWrench:o</tag>
+    </module>    
+    <connection>
+        <from>/wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o</from>
+        <to>/dumper/icubSim/right_foot/cartesianEndEffectorWrench:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+   
+    <!-- JOINT STATES -->
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/all_joints/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-all_joints-state:o</tag>
+    </module>    
+    <connection>
+        <from>/icubSim/all_joints/state:o</from>
+        <to>/dumper/icubSim/all_joints/state:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+
+</application>

--- a/scripts/walking-dumper-sim.xml
+++ b/scripts/walking-dumper-sim.xml
@@ -1,0 +1,139 @@
+<!-- Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia (IIT) -->
+<!-- All Rights Reserved. -->
+
+<application>
+    
+    <name>Walking data dumper module</name>
+    <description>collects data from the sensor suite for offline processing</description>
+    <authors>
+        <author email="prashanth.ramadoss@iit.it">Prashanth Ramadoss</author>
+        <author email="silvio.traversaro@iit.it">Silvio Traversaro</author>
+    </authors>
+
+    <dependencies>
+        <!-- VIO -->
+        <port>/icubSim/inertial</port>
+                  
+        
+        <!-- BASE IMU -->
+        <port>/icubSim/xsens_inertial</port>
+        
+        <!-- CONTACT WRENCHES -->
+        <port>/wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o</port>
+        <port>/wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o</port>
+        
+        <!-- JOINT STATES -->
+        <port>/icubSim/all_joints/stateExt:o</port>
+        
+        <!-- Link states  -->        
+        <port>/icubSim/floating_base/state:o</port>
+        <port>/icubSim/l_foot/state:o</port>
+        <port>/icubSim/r_foot/state:o</port>
+    </dependencies>
+    
+    
+    <!-- Link states  -->   
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/floating_base/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-floating_base-state:o</tag>
+    </module>
+    <connection>
+        <from>/icubSim/floating_base/state:o</from>
+        <to>/dumper/icubSim/floating_base/state:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/l_foot/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-l_foot-state:o</tag>
+    </module>
+    <connection>
+        <from>/icubSim/l_foot/state:o</from>
+        <to>/dumper/icubSim/l_foot/state:o</to>
+        <protocol>udp</protocol>        
+    </connection> 
+    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/r_foot/state:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-r_foot-state:o</tag>
+    </module>
+    <connection>
+        <from>/icubSim/r_foot/state:o</from>
+        <to>/dumper/icubSim/r_foot/state:o</to>
+        <protocol>udp</protocol>        
+    </connection>  
+    
+    <!-- VIO -->
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/head/inertial --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-head-inertial</tag>
+    </module>
+    <connection>
+        <from>/icubSim/inertial</from>
+        <to>/dumper/icubSim/head/inertial</to>
+        <protocol>udp</protocol>        
+    </connection>    
+    
+           
+    <!-- BASE IMU -->    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/waist/inertial --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-waist-inertial</tag>
+    </module>    
+    <connection>
+        <from>/icubSim/xsens_inertial</from>
+        <to>/dumper/icubSim/waist/inertial</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+    <!-- CONTACT WRENCHES -->
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/left_foot/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-left_foot-cartesianEndEffectorWrench:o</tag>
+    </module>    
+    <connection>
+        <from>/wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o</from>
+        <to>/dumper/icubSim/left_foot/cartesianEndEffectorWrench:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/right_foot/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-right_foot-cartesianEndEffectorWrench:o</tag>
+    </module>    
+    <connection>
+        <from>/wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o</from>
+        <to>/dumper/icubSim/right_foot/cartesianEndEffectorWrench:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+   
+    <!-- JOINT STATES -->
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icubSim/all_joints/stateExt:o --type bottle  --txTime --rxTime</parameters>
+        <node>localhost</node>
+        <tag>walking-data-dumper-icubSim-all_joints-stateExt:o</tag>
+    </module>    
+    <connection>
+        <from>/icubSim/all_joints/stateExt:o</from>
+        <to>/dumper/icubSim/all_joints/stateExt:o</to>
+        <protocol>udp</protocol>        
+    </connection>
+    
+
+</application>

--- a/scripts/walking-dumper.xml
+++ b/scripts/walking-dumper.xml
@@ -46,7 +46,7 @@
     <!-- realsense -->
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/depthCamera/rgbImage:o --type image</parameters>
+        <parameters>--name /dumper/depthCamera/rgbImage:o --type image  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-depthCamera-rgbImage</tag>
     </module>
@@ -58,7 +58,7 @@
 
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/depthCamera/depthImage:o --type image</parameters>
+        <parameters>--name /dumper/depthCamera/depthImage:o --type image  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-depthCamera-depthImage</tag>
     </module>
@@ -71,7 +71,7 @@
     <!-- VIO -->
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/head/inertial --type bottle</parameters>
+        <parameters>--name /dumper/icub/head/inertial --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-head-inertial</tag>
     </module>
@@ -83,7 +83,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/head/camcalib/left --type image</parameters>
+        <parameters>--name /dumper/icub/head/camcalib/left --type image  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-head-camcalib-left</tag>
     </module>
@@ -95,7 +95,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/head/camcalib/right --type image</parameters>
+        <parameters>--name /dumper/icub/head/camcalib/right --type image  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-head-camcalib-right</tag>
     </module>
@@ -107,7 +107,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/head/state:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/head/state:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-head-state:o</tag>
     </module>
@@ -120,7 +120,7 @@
     <!-- BASE IMU -->    
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/waist/inertial --type bottle</parameters>
+        <parameters>--name /dumper/icub/waist/inertial --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-waist-inertial</tag>
     </module>    
@@ -133,7 +133,7 @@
     <!-- CONTACT WRENCHES -->
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/left_foot/cartesianEndEffectorWrench:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/left_foot/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-left_foot-cartesianEndEffectorWrench:o</tag>
     </module>    
@@ -145,7 +145,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/right_foot/cartesianEndEffectorWrench:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/right_foot/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-right_foot-cartesianEndEffectorWrench:o</tag>
     </module>    
@@ -157,7 +157,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/left_arm/cartesianEndEffectorWrench:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/left_arm/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-left_arm-cartesianEndEffectorWrench:o</tag>
     </module>    
@@ -169,7 +169,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/right_arm/cartesianEndEffectorWrench:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/right_arm/cartesianEndEffectorWrench:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-right_arm-cartesianEndEffectorWrench:o</tag>
     </module>    
@@ -182,7 +182,7 @@
     <!-- JOINT STATES -->
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/all_joints/stateExt:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/all_joints/stateExt:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-all_joints-stateExt:o</tag>
     </module>    
@@ -195,7 +195,7 @@
     <!-- 6 AXIS FT SENSORS -->
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/left_arm/analog:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/left_arm/analog:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-left_arm-analog:o</tag>
     </module>    
@@ -207,7 +207,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/right_arm/analog:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/right_arm/analog:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-right_arm-analog:o</tag>
     </module>    
@@ -219,7 +219,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/left_leg/measures:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/left_leg/measures:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-left_leg-measures:o</tag>
     </module>    
@@ -231,7 +231,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/right_leg/measures:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/right_leg/measures:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-right_leg-measures:o</tag>
     </module>    
@@ -243,7 +243,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/left_foot/measures:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/left_foot/measures:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-left_foot-measures:o</tag>
     </module>    
@@ -255,7 +255,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/right_foot/measures:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/right_foot/measures:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-right_foot-measures:o</tag>
     </module>    
@@ -267,7 +267,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/left_leg/inertials/measures:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/left_leg/inertials/measures:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-left_leg-inertials-measures:o</tag>
     </module>    
@@ -279,7 +279,7 @@
     
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /dumper/icub/right_leg/inertials/measures:o --type bottle</parameters>
+        <parameters>--name /dumper/icub/right_leg/inertials/measures:o --type bottle  --txTime --rxTime</parameters>
         <node>localhost</node>
         <tag>walking-data-dumper-icub-right_leg-inertials-measures:o</tag>
     </module>    


### PR DESCRIPTION
Previously with the dumper applications, we were not actually dumping received timestamps, instead, we were only dumping sender timestamps. This causes problems in time synchronization of measurement sets during offline processing. Also, it is always a safe practice to deal with RX timestamps in sensor fusion algorithms. 

This PR does the following,
- adds an option to dump also the RX timestamps along with the TX timestamps
- adds a dumper application to record data for simulated walking experiments. The measurement sets include ground truth state for the base link and the foot links

cc @HosameldinMohamed please be aware of these changes. This might have affected or might affect your experiments. 